### PR TITLE
mapping mpich env variable for multi-node training

### DIFF
--- a/intel_extension_for_deepspeed/xpu_accelerator.py
+++ b/intel_extension_for_deepspeed/xpu_accelerator.py
@@ -8,6 +8,15 @@ class XPU_Accelerator(DeepSpeedAccelerator):
     def __init__(self):
         self._name = 'xpu'
         self._communication_backend_name = 'ccl'
+        def _check_and_mapping_mpich_env():
+            import os
+            if  "RANK" not in os.environ and "PMI_RANK" in os.environ:
+                os.environ['RANK'] = os.environ.get('PMI_RANK')
+                print("mapping environment variable PMI_RANK to RANK")
+            if  "WORLD_SIZE" not in os.environ and "PMI_SIZE" in os.environ:
+                os.environ['WORLD_SIZE'] = os.environ.get('PMI_SIZE')
+                print("mapping environment variable PMI_SIZE to WORLD_SIZE")
+        _check_and_mapping_mpich_env()
 
     # Device APIs
     def device_name(self, device_index=None):


### PR DESCRIPTION
For multi-node training, mapping MPICH environment variable.  No need to modify Megatron.
Work with MPICH launcher. 