### PR TITLE
New interface to tell DeepSpeed that XPU Accelerator is not synchronized

### DIFF
--- a/intel_extension_for_deepspeed/xpu_accelerator.py
+++ b/intel_extension_for_deepspeed/xpu_accelerator.py
@@ -18,6 +18,9 @@ class XPU_Accelerator(DeepSpeedAccelerator):
                 print("mapping environment variable PMI_SIZE to WORLD_SIZE")
         _check_and_mapping_mpich_env()
 
+    def is_synchronized_device(self):
+        return False
+
     # Device APIs
     def device_name(self, device_index=None):
         if device_index == None:


### PR DESCRIPTION
This PR add a new interface is_synchrnozed_device() which always return False, this is to work with the pending interface change in https://github.com/microsoft/DeepSpeed/pull/3041/files#diff-063566e7665f62d56f954817035fb24b21a1395225ca5d1ae792e60220c98e42R12

Note: even before PR#3041 in DeepSpeed merged, this PR still works.  But when we use #3041 to test on PVC, without this PR DeepSpeed will fail on PVC.