### PR TITLE
fix transformer.py for jit load UT pass

### DIFF
--- a/intel_extension_for_deepspeed/op_builder/transformer.py
+++ b/intel_extension_for_deepspeed/op_builder/transformer.py
@@ -16,7 +16,7 @@ class TransformerBuilder(SYCLOpBuilder):
         return f'deepspeed.ops.transformer.{self.NAME}_op'
 
     def extra_ldflags(self):
-        return []
+        return super().extra_ldflags()
 
     def sources(self):
         return [


### PR DESCRIPTION
The former extra_ldflags will remove the ldflags in build.py, fix this issue, to support pass the UT when use jit-load.