### PR TITLE
update kernel for new compiler

### DIFF
--- a/intel_extension_for_deepspeed/op_builder/csrc/includes/context.hpp
+++ b/intel_extension_for_deepspeed/op_builder/csrc/includes/context.hpp
@@ -13,12 +13,12 @@
 #error "Unsupported compiler"
 #endif
 #include <cassert>
-#include <ext/oneapi/experimental/bfloat16.hpp>
+#include <ext/oneapi/bfloat16.hpp>
 #include <iostream>
 #include <oneapi/mkl.hpp>
 #include <oneapi/mkl/rng/device.hpp>
 #include <vector>
-using bf16 = sycl::ext::oneapi::experimental::bfloat16;
+using bf16 = sycl::ext::oneapi::bfloat16;
 
 #define WARP_SIZE 32
 #define ONEMKL_OP_T oneapi::mkl::transpose::trans

--- a/intel_extension_for_deepspeed/op_builder/csrc/includes/onednn_wrappers.hpp
+++ b/intel_extension_for_deepspeed/op_builder/csrc/includes/onednn_wrappers.hpp
@@ -8,9 +8,9 @@ using namespace cl::sycl;
 #else
 #error "Unsupported compiler"
 #endif
-#include <ext/oneapi/experimental/bfloat16.hpp>
+#include <ext/oneapi/bfloat16.hpp>
 
-using bf16 = sycl::ext::oneapi::experimental::bfloat16;
+using bf16 = sycl::ext::oneapi::bfloat16;
 
 int onednn_matmul_ex(sycl::queue* handle,
                      bool trans_src,

--- a/intel_extension_for_deepspeed/op_builder/csrc/transformer/gelu_kernels.dp.cpp
+++ b/intel_extension_for_deepspeed/op_builder/csrc/transformer/gelu_kernels.dp.cpp
@@ -7,9 +7,9 @@ using namespace cl::sycl;
 #else
 #error "Unsupported compiler"
 #endif
-#include <ext/oneapi/experimental/bfloat16.hpp>
+#include <ext/oneapi/bfloat16.hpp>
 
-using bf16 = sycl::ext::oneapi::experimental::bfloat16;
+using bf16 = sycl::ext::oneapi::bfloat16;
 
 inline float gelu(const float x)
 {
@@ -159,14 +159,14 @@ void fused_bias_gelu(const bf16* input,
             ushort4 vals_vec = input_cast[row * row_stride + i * loop_stride + id];
             ushort4 bias_vec = bias_cast[i * loop_stride + id];
 
-            float4 data = {bf16::to_float(vals_vec.x()),
-                           bf16::to_float(vals_vec.y()),
-                           bf16::to_float(vals_vec.z()),
-                           bf16::to_float(vals_vec.w())};
-            float4 bias = {bf16::to_float(bias_vec.x()),
-                           bf16::to_float(bias_vec.y()),
-                           bf16::to_float(bias_vec.z()),
-                           bf16::to_float(bias_vec.w())};
+            float4 data = {float(vals_vec.x()),
+                           float(vals_vec.y()),
+                           float(vals_vec.z()),
+                           float(vals_vec.w())};
+            float4 bias = {float(bias_vec.x()),
+                           float(bias_vec.y()),
+                           float(bias_vec.z()),
+                           float(bias_vec.w())};
 
             data += bias;
 
@@ -175,10 +175,10 @@ void fused_bias_gelu(const bf16* input,
             data.z() = gelu(data.z());
             data.w() = gelu(data.w());
 
-            vals_vec.x() = bf16::from_float(data.x());
-            vals_vec.y() = bf16::from_float(data.y());
-            vals_vec.z() = bf16::from_float(data.z());
-            vals_vec.w() = bf16::from_float(data.w());
+            vals_vec.x() = bf16(data.x());
+            vals_vec.y() = bf16(data.y());
+            vals_vec.z() = bf16(data.z());
+            vals_vec.w() = bf16(data.w());
 
             vals_cast[row * row_stride + i * loop_stride + id] = vals_vec;
         }
@@ -289,21 +289,21 @@ void d_gelu_func(bf16* d_output,
             ushort4 gelu_input_vec = gelu_input_cast[row * row_stride + i * loop_stride + id];
             ushort4 bias_vec = bias_cast[i * loop_stride + id];
 
-            float4 gelu_input_data = {bf16::to_float(gelu_input_vec.x()),
-                                      bf16::to_float(gelu_input_vec.y()),
-                                      bf16::to_float(gelu_input_vec.z()),
-                                      bf16::to_float(gelu_input_vec.w())};
+            float4 gelu_input_data = {float(gelu_input_vec.x()),
+                                      float(gelu_input_vec.y()),
+                                      float(gelu_input_vec.z()),
+                                      float(gelu_input_vec.w())};
             float4 bias_data = {
-                bf16::to_float(bias_vec.x()),
-                bf16::to_float(bias_vec.y()),
-                bf16::to_float(bias_vec.z()),
-                bf16::to_float(bias_vec.w()),
+                float(bias_vec.x()),
+                float(bias_vec.y()),
+                float(bias_vec.z()),
+                float(bias_vec.w()),
             };
             float4 output_data = {
-                bf16::to_float(output_vec.x()),
-                bf16::to_float(output_vec.y()),
-                bf16::to_float(output_vec.z()),
-                bf16::to_float(output_vec.w()),
+                float(output_vec.x()),
+                float(output_vec.y()),
+                float(output_vec.z()),
+                float(output_vec.w()),
             };
 
             gelu_input_data.x() += bias_data.x();
@@ -316,10 +316,10 @@ void d_gelu_func(bf16* d_output,
             output_data.z() *= d_gelu(gelu_input_data.z());
             output_data.w() *= d_gelu(gelu_input_data.w());
 
-            output_vec.x() = bf16::from_float(output_data.x());
-            output_vec.y() = bf16::from_float(output_data.y());
-            output_vec.z() = bf16::from_float(output_data.z());
-            output_vec.w() = bf16::from_float(output_data.w());
+            output_vec.x() = bf16(output_data.x());
+            output_vec.y() = bf16(output_data.y());
+            output_vec.z() = bf16(output_data.z());
+            output_vec.w() = bf16(output_data.w());
             d_output_cast[row * row_stride + i * loop_stride + id] = output_vec;
         }
     }

--- a/intel_extension_for_deepspeed/op_builder/csrc/transformer/general_kernels.dp.cpp
+++ b/intel_extension_for_deepspeed/op_builder/csrc/transformer/general_kernels.dp.cpp
@@ -73,7 +73,7 @@ void column_sum_reduce(const bf16* inp,
     if (idx < width) {
         int offset = item_ct1.get_local_id(1) * width + idx;
         for (int r = item_ct1.get_local_id(1); r < rows; r += MAX_SG_NUM) {
-            localSum += bf16::to_float(inp_cast[offset]);
+            localSum += float(inp_cast[offset]);
             offset += y_stride;
         }
     }
@@ -93,7 +93,7 @@ void column_sum_reduce(const bf16* inp,
 
     if (item_ct1.get_local_id(2) == 0) {
         int pos = item_ct1.get_group(2) * MAX_SG_NUM + item_ct1.get_local_id(1);
-        if (pos < width) out_cast[pos] = bf16::from_float(sum);
+        if (pos < width) out_cast[pos] = bf16(sum);
     }
 }
 
@@ -168,24 +168,24 @@ void fused_add2_kernel(const int N,
     DPCPP_1D_KERNEL_LOOP(j, N)
     {
         float4 val;
-        float4 inp1_reg = {bf16::to_float(inp1_cast[j].x()),
-                           bf16::to_float(inp1_cast[j].y()),
-                           bf16::to_float(inp1_cast[j].z()),
-                           bf16::to_float(inp1_cast[j].w())};
-        float4 inp2_reg = {bf16::to_float(inp2_cast[j].x()),
-                           bf16::to_float(inp2_cast[j].y()),
-                           bf16::to_float(inp2_cast[j].z()),
-                           bf16::to_float(inp2_cast[j].w())};
+        float4 inp1_reg = {float(inp1_cast[j].x()),
+                           float(inp1_cast[j].y()),
+                           float(inp1_cast[j].z()),
+                           float(inp1_cast[j].w())};
+        float4 inp2_reg = {float(inp2_cast[j].x()),
+                           float(inp2_cast[j].y()),
+                           float(inp2_cast[j].z()),
+                           float(inp2_cast[j].w())};
 
         val.x() = inp1_reg.x() + inp2_reg.x();
         val.y() = inp1_reg.y() + inp2_reg.y();
         val.z() = inp1_reg.z() + inp2_reg.z();
         val.w() = inp1_reg.w() + inp2_reg.w();
 
-        out_cast[j] = {bf16::from_float(val.x()),
-                       bf16::from_float(val.y()),
-                       bf16::from_float(val.z()),
-                       bf16::from_float(val.w())};
+        out_cast[j] = {bf16(val.x()),
+                       bf16(val.y()),
+                       bf16(val.z()),
+                       bf16(val.w())};
     }
 }
 

--- a/intel_extension_for_deepspeed/op_builder/csrc/transformer/softmax_kernels.dp.cpp
+++ b/intel_extension_for_deepspeed/op_builder/csrc/transformer/softmax_kernels.dp.cpp
@@ -184,14 +184,14 @@ void attn_softmax(bf16* vals,
         if (data_id < seq_length) {
             ushort4 mask_ushort = attn_mask_cast[mask_offset + data_id];
             ushort4 val_ushort = val_cast[data_offset + data_id];
-            float4 mask = {bf16::to_float(mask_ushort.x()),
-                           bf16::to_float(mask_ushort.y()),
-                           bf16::to_float(mask_ushort.z()),
-                           bf16::to_float(mask_ushort.w())};
-            data[i] = {bf16::to_float(val_ushort.x()),
-                       bf16::to_float(val_ushort.y()),
-                       bf16::to_float(val_ushort.z()),
-                       bf16::to_float(val_ushort.w())};
+            float4 mask = {float(mask_ushort.x()),
+                           float(mask_ushort.y()),
+                           float(mask_ushort.z()),
+                           float(mask_ushort.w())};
+            data[i] = {float(val_ushort.x()),
+                       float(val_ushort.y()),
+                       float(val_ushort.z()),
+                       float(val_ushort.w())};
 
             data[i].x() += mask.x();
             data[i].y() += mask.y();
@@ -278,10 +278,10 @@ void attn_softmax(bf16* vals,
 
         int data_id = i * iteration_stride + seq_lane;
         if (data_id < seq_length) {
-            ushort4 data_ushort = {bf16::from_float(data[i].x()),
-                                   bf16::from_float(data[i].y()),
-                                   bf16::from_float(data[i].z()),
-                                   bf16::from_float(data[i].w())};
+            ushort4 data_ushort = {bf16(data[i].x()),
+                                   bf16(data[i].y()),
+                                   bf16(data[i].z()),
+                                   bf16(data[i].w())};
             val_cast[data_offset + data_id] = data_ushort;
         }
     }
@@ -726,8 +726,8 @@ void softmax_backward_kernel_v2(T* grad /* input & output*/,
         for (int i = 0; i < ITERATIONS; ++i) {
             int curr_idx = item_ct1.get_local_id(2) + i * MAX_SG_NUM;
             if (curr_idx < softmax_length) {
-                grad_reg[i] = bf16::to_float(grad_cast[i * MAX_SG_NUM]);
-                output_reg[i] = bf16::to_float(output_cast[i * MAX_SG_NUM]);
+                grad_reg[i] = float(grad_cast[i * MAX_SG_NUM]);
+                output_reg[i] = float(output_cast[i * MAX_SG_NUM]);
                 sum += grad_reg[i] * output_reg[i];
             }
         }
@@ -740,7 +740,7 @@ void softmax_backward_kernel_v2(T* grad /* input & output*/,
         for (int i = 0; i < ITERATIONS; ++i) {
             int curr_idx = item_ct1.get_local_id(2) + i * MAX_SG_NUM;
             if (curr_idx < softmax_length) {
-                grad_cast[i * MAX_SG_NUM] = bf16::from_float(output_reg[i] * (grad_reg[i] - sum));
+                grad_cast[i * MAX_SG_NUM] = bf16(output_reg[i] * (grad_reg[i] - sum));
             }
         }
     } else {

--- a/intel_extension_for_deepspeed/op_builder/csrc/transformer/transform_kernels.dp.cpp
+++ b/intel_extension_for_deepspeed/op_builder/csrc/transformer/transform_kernels.dp.cpp
@@ -145,10 +145,10 @@ void transform_0213<bf16>(bf16* output,
     sycl::ushort4* output_vec = reinterpret_cast<sycl::ushort4*>(output);
 
     sycl::ushort4 inputs_cast = vals_vec[d0 * d0_stride + d1 * d1_stride + d2 * d2_stride + d3];
-    float4 inputs = {bf16::to_float(inputs_cast.x()),
-                     bf16::to_float(inputs_cast.y()),
-                     bf16::to_float(inputs_cast.z()),
-                     bf16::to_float(inputs_cast.w())};
+    float4 inputs = {float(inputs_cast.x()),
+                     float(inputs_cast.y()),
+                     float(inputs_cast.z()),
+                     float(inputs_cast.w())};
 
     sycl::float4 outputs;
     outputs.x() = inputs.x();
@@ -156,10 +156,10 @@ void transform_0213<bf16>(bf16* output,
     outputs.z() = inputs.z();
     outputs.w() = inputs.w();
 
-    ushort4 outputs_cast = {bf16::from_float(outputs.x()),
-                            bf16::from_float(outputs.y()),
-                            bf16::from_float(outputs.z()),
-                            bf16::from_float(outputs.w())};
+    ushort4 outputs_cast = {bf16(outputs.x()),
+                            bf16(outputs.y()),
+                            bf16(outputs.z()),
+                            bf16(outputs.w())};
 
     output_vec[d0 * d0_out_stride + d1 * d1_out_stride + d2 * d2_out_stride + d3] = outputs_cast;
 }
@@ -353,15 +353,15 @@ void bias_add_transform_0213<bf16>(bf16* output,
         vals_vec[d0 * d0_stride * (item_ct1.get_group_range(0) / head_ext) + cnt * d1_stride +
                  d1 * d1_stride * (item_ct1.get_group_range(0) / head_ext) + d2 * d2_stride + d3];
     sycl::ushort4 biases_cast = bias_vec[cnt * d1_stride + d2 * d2_stride + d3];
-    float4 inputs = {bf16::to_float(inputs_cast.x()),
-                     bf16::to_float(inputs_cast.y()),
-                     bf16::to_float(inputs_cast.z()),
-                     bf16::to_float(inputs_cast.w())};
+    float4 inputs = {float(inputs_cast.x()),
+                     float(inputs_cast.y()),
+                     float(inputs_cast.z()),
+                     float(inputs_cast.w())};
 
-    float4 biases = {bf16::to_float(biases_cast.x()),
-                     bf16::to_float(biases_cast.y()),
-                     bf16::to_float(biases_cast.z()),
-                     bf16::to_float(biases_cast.w())};
+    float4 biases = {float(biases_cast.x()),
+                     float(biases_cast.y()),
+                     float(biases_cast.z()),
+                     float(biases_cast.w())};
 
     sycl::float4 outputs;
     outputs.x() = inputs.x() + biases.x();
@@ -369,10 +369,10 @@ void bias_add_transform_0213<bf16>(bf16* output,
     outputs.z() = inputs.z() + biases.z();
     outputs.w() = inputs.w() + biases.w();
 
-    ushort4 outputs_cast = {bf16::from_float(outputs.x()),
-                            bf16::from_float(outputs.y()),
-                            bf16::from_float(outputs.z()),
-                            bf16::from_float(outputs.w())};
+    ushort4 outputs_cast = {bf16(outputs.x()),
+                            bf16(outputs.y()),
+                            bf16(outputs.z()),
+                            bf16(outputs.w())};
     output_vec[cnt * d0_out_stride * item_ct1.get_group_range(2) + d0 * d0_out_stride +
                d1 * d1_out_stride + d2 * d2_out_stride + d3] = outputs_cast;
 }


### PR DESCRIPTION
Update the sycl kernel code to match the latest dpcpp compiler, the method (from_float) and (to_float) becomes private method, and use the recommended method to replace according to compiler's code given.