### PR TITLE
 builder.py: fix python dict query code

### DIFF
--- a/intel_extension_for_deepspeed/op_builder/builder.py
+++ b/intel_extension_for_deepspeed/op_builder/builder.py
@@ -53,7 +53,7 @@ class SYCLOpBuilder(OpBuilder):
 
     def load(self, verbose=True):
         from deepspeed.git_version_info import installed_ops, torch_info  # noqa: F401
-        if installed_ops[self.name]:
+        if self.name in installed_ops:
             return importlib.import_module(self.absolute_name())
         else:
             return self.jit_load(verbose)


### PR DESCRIPTION
While using Buiilder.load(), installed_ops is used to determine how we should load our kernel. If install deepseed by pip, this "installed_ops" would not contain ops info. Need to change its conditions or "Key Error" would occur.