### PR TITLE
xpu_accelerator.py: add supported_dtypes function

### DIFF
--- a/intel_extension_for_deepspeed/xpu_accelerator.py
+++ b/intel_extension_for_deepspeed/xpu_accelerator.py
@@ -150,6 +150,9 @@ class XPU_Accelerator(DeepSpeedAccelerator):
     def is_fp16_supported(self):
         return True
 
+    def supported_dtypes(self):
+        return [torch.float, torch.half, torch.bfloat16]
+
     # Tensor operations
 
     @property


### PR DESCRIPTION
Latest deepspeed has this function in its abstract accelerator class, this PR is to add this in our intel_extension_for_deepseed to align with deepseed.
Ref: https://github.com/microsoft/DeepSpeed/blob/master/accelerator/cuda_accelerator.py#L150
https://github.com/microsoft/DeepSpeed/blob/master/accelerator/cpu_accelerator.py#L188