### PR TITLE
fix build error with DeepSpeed triton support

### DIFF
--- a/intel_extension_for_deepspeed/xpu_accelerator.py
+++ b/intel_extension_for_deepspeed/xpu_accelerator.py
@@ -143,6 +143,9 @@ class XPU_Accelerator(DeepSpeedAccelerator):
     def communication_backend_name(self):
         return self._communication_backend_name
 
+    def is_triton_supported(self):
+        return False
+
     # Data types
     def is_bf16_supported(self):
         return True


### PR DESCRIPTION
- https://github.com/microsoft/DeepSpeed/pull/4337
DeepSpeed's abstract class for accelerator add:
```python
    @abc.abstractmethod
    def is_triton_supported(self):
        ...
```
cause build error with idex like:
![image](https://github.com/intel/intel-extension-for-deepspeed/assets/13817444/daac4d1a-37db-442f-b32a-a1f4455c43ab)

