### PR TITLE
Support bf16 type for transformer inference kernel to support Ds_Chat

### DIFF
--- a/intel_extension_for_deepspeed/op_builder/transformer_inference.py
+++ b/intel_extension_for_deepspeed/op_builder/transformer_inference.py
@@ -20,6 +20,11 @@ class InferenceBuilder(SYCLOpBuilder):
     def is_compatible(self, verbose=True):
         return super().is_compatible(verbose)
 
+    def cxx_args(self):
+        args = super().cxx_args()
+        args.append('-DBF16_AVAILABLE')
+        return args
+
     def sources(self):
         return [
             sycl_kernel_path('csrc/transformer/inference/csrc/pt_binding.cpp'),


### PR DESCRIPTION
Add the flag to support bf16 type for transformer inference kernel to enable Deepspeed-Chat