### PR TITLE
Set overlap_comm=false to use the same stream for computation and compuatation

### DIFF
--- a/examples/generate_config.sh
+++ b/examples/generate_config.sh
@@ -85,7 +85,7 @@ zero="\
       \"stage3_param_persistence_threshold\": 1e5,
       \"stage3_prefetch_bucket_size\": 5e7,
       \"contiguous_gradients\": true,
-      \"overlap_comm\": true,
+      \"overlap_comm\": false,
       \"reduce_bucket_size\": 90000000,
       \"sub_group_size\": 1e9,
       \"offload_optimizer\": {


### PR DESCRIPTION
with the overlap_comm=true to use the multi-streams for communication and computation will cause the power limitation and external PROCHOT assertion to limited the frequency to affect the performance, when overlap_comm=false to use the same stream for communication and computation can get better performance.