### PR TITLE
[Config]modify the zero2 config align to zero3

### DIFF
--- a/examples/generate_config.sh
+++ b/examples/generate_config.sh
@@ -96,7 +96,25 @@ zero="\
         \"pin_memory\": true
       }
     },"
-elif [ $ZERO_STAGE == 2 ] || [ $ZERO_STAGE == 1 ]; then
+elif [ $ZERO_STAGE == 2 ]; then
+zero="\
+    \"zero_optimization\": {
+      \"stage\": $ZERO_STAGE,
+      \"allgather_partitions\": true,
+      \"allgather_bucket_size\": \"auto\",
+      \"overlap_comm\": true,
+      \"reduce_scatter\": false,
+      \"reduce_bucket_size\": 3e7,
+      \"contiguous_gradients\": true,
+      \"offload_optimizer\": {
+        \"device\": \"none\",
+        \"buffer_count\": 4,
+        \"pipeline_read\": false,
+        \"pipeline_write\": false,
+        \"pin_memory\": true
+      }
+    },"
+elif [ $ZERO_STAGE == 1 ]; then
 zero="\
     \"zero_optimization\": {
       \"stage\": $ZERO_STAGE


### PR DESCRIPTION
For zero2 and zero3 will both partition the gradient, some configs previously worked for zero3 will also benefit for zero2 like("contiguous_gradients"), if we want to compare the performance between zero2 and zero3, the config should be same, then we can see performance for zero2 is always better than zero3.