### PR TITLE
set comm_overlap as true by default for Zero3

### DIFF
--- a/examples/generate_config.sh
+++ b/examples/generate_config.sh
@@ -85,7 +85,7 @@ zero="\
       \"stage3_param_persistence_threshold\": 1e5,
       \"stage3_prefetch_bucket_size\": 5e7,
       \"contiguous_gradients\": true,
-      \"overlap_comm\": false,
+      \"overlap_comm\": true,
       \"reduce_bucket_size\": 90000000,
       \"sub_group_size\": 1e9,
       \"offload_optimizer\": {


### PR DESCRIPTION
Which can get 1%-2% percentage performance improvement for scale-out and this is the feature we are WIP, should set by default.