### PR TITLE
[manifest] update mainfest to add h file in idex

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include intel_extension_for_deepspeed/op_builder/csrc *.cpp *.hpp
+recursive-include intel_extension_for_deepspeed/op_builder/csrc *.cpp *.hpp *.h
 recursive-include intel_extension_for_deepspeed *.py


### PR DESCRIPTION
To make sure *.h file in idex package, fix the build issue when using fused_adam.