### PR TITLE
[Zero2_Config]Increase the bucket_size to align with Zero3

### DIFF
--- a/examples/generate_config.sh
+++ b/examples/generate_config.sh
@@ -104,7 +104,7 @@ zero="\
       \"allgather_bucket_size\": \"auto\",
       \"overlap_comm\": true,
       \"reduce_scatter\": false,
-      \"reduce_bucket_size\": 3e7,
+      \"reduce_bucket_size\": 90000000,
       \"contiguous_gradients\": true,
       \"offload_optimizer\": {
         \"device\": \"none\",


### PR DESCRIPTION
Increase the bucket size to align with zero3 and can also WA the nan issue when running llama model with Zero2.